### PR TITLE
fix(modules): refer to correct field for driver type

### DIFF
--- a/apps/backoffice/src/app/systems/system-modules.component.ts
+++ b/apps/backoffice/src/app/systems/system-modules.component.ts
@@ -181,7 +181,7 @@ import { SystemStateService } from './system-state.service';
                                     </div>
                                 </div>
                                 <div class="w-24 p-2" i18n="@@driverType">
-                                    { driver_type(device.driver?.role), select,
+                                    { driver_type(device.role), select,
                                     Device { Device } Logic { Logic } SSH { SSH
                                     } Websocket { Websocket } Service { Service
                                     } other { Other } }


### PR DESCRIPTION
**Description of the change**

Code was referring to a field that seems to no longer exists. Referring to the correct field will now display the correct driver type.

**Benefits**
Field will now display the correct driver type

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using # or link directly) -->
- fixes #284 

